### PR TITLE
jetbrains: add eap packages

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -675,6 +675,12 @@
     githubId = 858965;
     name = "Andrew Morsillo";
   };
+  AnatolyPopov = {
+    email = "aipopov@live.ru";
+    github = "AnatolyPopov";
+    githubId = 2312534;
+    name = "Anatolii Popov";
+  };
   andehen = {
     email = "git@andehen.net";
     github = "andehen";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -1,10 +1,17 @@
-{ lib, stdenv, callPackage, fetchurl
-, jdk, cmake, zlib, python3
+{ lib
+, stdenv
+, callPackage
+, fetchurl
+, jdk
+, cmake
+, zlib
+, python3
 , dotnet-sdk_5
 , maven
 , autoPatchelfHook
 , libdbusmenu
 , vmopts ? null
+, channel ? "release"
 }:
 
 with lib;
@@ -16,18 +23,32 @@ let
   inherit (stdenv.hostPlatform) system;
 
   versions = builtins.fromJSON (readFile (./versions.json));
-  versionKey = if stdenv.isLinux then "linux" else system;
-  products = versions.${versionKey} or (throw "Unsupported system: ${system}");
+  channelVersions = versions.${channel} or (throw "Unknown channel: ${channel}");
+  platformKey = if stdenv.isLinux then "linux" else system;
+  products = channelVersions.${platformKey} or (throw "Unsupported system: ${system}");
 
   package = if stdenv.isDarwin then ./darwin.nix else ./linux.nix;
   mkJetBrainsProduct = callPackage package { inherit vmopts; };
 
+  isStable = channel == "release";
+
+  pnameSuffix = if isStable then "" else "-${channel}";
+
+  productSuffix = version:
+    if isStable
+    then ""
+    else " ${builtins.replaceStrings ["Beta"] ["EAP"] version}";
+
+  packageName = name:
+    if isStable
+    then name
+    else "${name}-${channel}";
+
   # Sorted alphabetically
 
-  buildClion = { pname, version, src, license, description, wmClass, ... }:
+  buildClion = { pname, version, src, license, description, wmClass, product, ... }:
     (mkJetBrainsProduct {
-      inherit pname version src wmClass jdk;
-      product = "CLion";
+      inherit pname version src wmClass jdk product;
       meta = with lib; {
         homepage = "https://www.jetbrains.com/clion/";
         inherit description license platforms;
@@ -62,10 +83,9 @@ let
       '';
     });
 
-  buildDataGrip = { pname, version, src, license, description, wmClass, ... }:
+  buildDataGrip = { pname, version, src, license, description, wmClass, product, ... }:
     (mkJetBrainsProduct {
-      inherit pname version src wmClass jdk;
-      product = "DataGrip";
+      inherit pname version src wmClass jdk product;
       meta = with lib; {
         homepage = "https://www.jetbrains.com/datagrip/";
         inherit description license platforms;
@@ -78,10 +98,9 @@ let
       };
     });
 
-  buildGoland = { pname, version, src, license, description, wmClass, ... }:
+  buildGoland = { pname, version, src, license, description, wmClass, product, ... }:
     (mkJetBrainsProduct {
-      inherit pname version src wmClass jdk;
-      product = "Goland";
+      inherit pname version src wmClass jdk product;
       meta = with lib; {
         homepage = "https://www.jetbrains.com/go/";
         inherit description license platforms;
@@ -146,10 +165,9 @@ let
       };
     });
 
-  buildPhpStorm = { pname, version, src, license, description, wmClass, ... }:
+  buildPhpStorm = { pname, version, src, license, description, wmClass, product, ... }:
     (mkJetBrainsProduct {
       inherit pname version src wmClass jdk;
-      product = "PhpStorm";
       meta = with lib; {
         homepage = "https://www.jetbrains.com/phpstorm/";
         inherit description license platforms;
@@ -186,10 +204,9 @@ let
       };
     });
 
-  buildRider = { pname, version, src, license, description, wmClass, ... }:
+  buildRider = { pname, version, src, license, description, wmClass, product, ... }:
     (mkJetBrainsProduct {
-      inherit pname version src wmClass jdk;
-      product = "Rider";
+      inherit pname version src wmClass jdk product;
       meta = with lib; {
         homepage = "https://www.jetbrains.com/rider/";
         inherit description license platforms;
@@ -211,10 +228,9 @@ let
       '');
     });
 
-  buildRubyMine = { pname, version, src, license, description, wmClass, ... }:
+  buildRubyMine = { pname, version, src, license, description, wmClass, product, ... }:
     (mkJetBrainsProduct {
-      inherit pname version src wmClass jdk;
-      product = "RubyMine";
+      inherit pname version src wmClass jdk product;
       meta = with lib; {
         homepage = "https://www.jetbrains.com/ruby/";
         inherit description license platforms;
@@ -223,10 +239,9 @@ let
       };
     });
 
-  buildWebStorm = { pname, version, src, license, description, wmClass, ... }:
+  buildWebStorm = { pname, version, src, license, description, wmClass, product, ... }:
     (mkJetBrainsProduct {
       inherit pname version src wmClass jdk;
-      product = "WebStorm";
       meta = with lib; {
         homepage = "https://www.jetbrains.com/webstorm/";
         inherit description license platforms;
@@ -250,8 +265,9 @@ in
 {
   # Sorted alphabetically
 
-  clion = buildClion rec {
-    pname = "clion";
+  ${packageName "clion"} = buildClion rec {
+    pname = "clion${pnameSuffix}";
+    product = "CLion${productSuffix version}";
     version = products.clion.version;
     description  = "C/C++ IDE. New. Intelligent. Cross-platform";
     license = lib.licenses.unfree;
@@ -263,8 +279,9 @@ in
     update-channel = products.clion.update-channel;
   };
 
-  datagrip = buildDataGrip rec {
-    pname = "datagrip";
+  ${packageName "datagrip"} = buildDataGrip rec {
+    pname = "datagrip${pnameSuffix}";
+    product = "DataGrip${productSuffix version}";
     version = products.datagrip.version;
     description = "Your Swiss Army Knife for Databases and SQL";
     license = lib.licenses.unfree;
@@ -276,8 +293,9 @@ in
     update-channel = products.datagrip.update-channel;
   };
 
-  goland = buildGoland rec {
-    pname = "goland";
+  ${packageName "goland"} = buildGoland rec {
+    pname = "goland${pnameSuffix}";
+    product = "Goland${productSuffix version}";
     version = products.goland.version;
     description = "Up and Coming Go IDE";
     license = lib.licenses.unfree;
@@ -289,9 +307,9 @@ in
     update-channel = products.goland.update-channel;
   };
 
-  idea-community = buildIdea rec {
-    pname = "idea-community";
-    product = "IntelliJ IDEA CE";
+  ${packageName "idea-community"} = buildIdea rec {
+    pname = "idea-community${pnameSuffix}";
+    product = "IntelliJ IDEA CE${productSuffix version}";
     version = products.idea-community.version;
     description = "Integrated Development Environment (IDE) by Jetbrains, community edition";
     license = lib.licenses.asl20;
@@ -303,9 +321,9 @@ in
     update-channel = products.idea-community.update-channel;
   };
 
-  idea-ultimate = buildIdea rec {
-    pname = "idea-ultimate";
-    product = "IntelliJ IDEA";
+  ${packageName "idea-ultimate"} = buildIdea rec {
+    pname = "idea-ultimate${pnameSuffix}";
+    product = "IntelliJ IDEA${productSuffix version}";
     version = products.idea-ultimate.version;
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = lib.licenses.unfree;
@@ -317,8 +335,9 @@ in
     update-channel = products.idea-ultimate.update-channel;
   };
 
-  mps = buildMps rec {
-    pname = "mps";
+  # MPS does not have an EAP channel.
+  ${if isStable then "mps" else null} = buildMps rec {
+    pname = "mps${pnameSuffix}";
     product = "MPS ${products.mps.version}";
     version = products.mps.version;
     description = "Create your own domain-specific language";
@@ -331,8 +350,9 @@ in
     update-channel = products.mps.update-channel;
   };
 
-  phpstorm = buildPhpStorm rec {
-    pname = "phpstorm";
+  ${packageName "phpstorm"} = buildPhpStorm rec {
+    pname = "phpstorm${pnameSuffix}";
+    product = "PhpStorm${productSuffix version}";
     version = products.phpstorm.version;
     description = "Professional IDE for Web and PHP developers";
     license = lib.licenses.unfree;
@@ -344,9 +364,9 @@ in
     update-channel = products.phpstorm.update-channel;
   };
 
-  pycharm-community = buildPycharm rec {
-    pname = "pycharm-community";
-    product = "PyCharm CE";
+  ${packageName "pycharm-community"} = buildPycharm rec {
+    pname = "pycharm-community${pnameSuffix}";
+    product = "PyCharm CE${productSuffix version}";
     version = products.pycharm-community.version;
     description = "PyCharm Community Edition";
     license = lib.licenses.asl20;
@@ -358,9 +378,9 @@ in
     update-channel = products.pycharm-community.update-channel;
   };
 
-  pycharm-professional = buildPycharm rec {
-    pname = "pycharm-professional";
-    product = "PyCharm";
+  ${packageName "pycharm-professional"} = buildPycharm rec {
+    pname = "pycharm-professional${pnameSuffix}";
+    product = "PyCharm${productSuffix version}";
     version = products.pycharm-professional.version;
     description = "PyCharm Professional Edition";
     license = lib.licenses.unfree;
@@ -372,8 +392,9 @@ in
     update-channel = products.pycharm-professional.update-channel;
   };
 
-  rider = buildRider rec {
-    pname = "rider";
+  ${packageName "rider"} = buildRider rec {
+    pname = "rider${pnameSuffix}";
+    product = "Rider${productSuffix version}";
     version = products.rider.version;
     description = "A cross-platform .NET IDE based on the IntelliJ platform and ReSharper";
     license = lib.licenses.unfree;
@@ -385,8 +406,9 @@ in
     update-channel = products.rider.update-channel;
   };
 
-  ruby-mine = buildRubyMine rec {
-    pname = "ruby-mine";
+  ${packageName "ruby-mine"} = buildRubyMine rec {
+    pname = "ruby-mine${pnameSuffix}";
+    product = "RubyMine${productSuffix version}";
     version = products.ruby-mine.version;
     description = "The Most Intelligent Ruby and Rails IDE";
     license = lib.licenses.unfree;
@@ -398,8 +420,9 @@ in
     update-channel = products.ruby-mine.update-channel;
   };
 
-  webstorm = buildWebStorm rec {
-    pname = "webstorm";
+  ${packageName "webstorm"} = buildWebStorm rec {
+    pname = "webstorm${pnameSuffix}";
+    product = "WebStorm${productSuffix version}";
     version = products.webstorm.version;
     description = "Professional IDE for Web and JavaScript development";
     license = lib.licenses.unfree;

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -260,7 +260,7 @@ in
       sha256 = products.clion.sha256;
     };
     wmClass = "jetbrains-clion";
-    update-channel = "CLion RELEASE"; # channel's id as in http://www.jetbrains.com/updates/updates.xml
+    update-channel = products.clion.update-channel;
   };
 
   datagrip = buildDataGrip rec {
@@ -273,7 +273,7 @@ in
       sha256 = products.datagrip.sha256;
     };
     wmClass = "jetbrains-datagrip";
-    update-channel = "DataGrip RELEASE";
+    update-channel = products.datagrip.update-channel;
   };
 
   goland = buildGoland rec {
@@ -286,7 +286,7 @@ in
       sha256 = products.goland.sha256;
     };
     wmClass = "jetbrains-goland";
-    update-channel = "GoLand RELEASE";
+    update-channel = products.goland.update-channel;
   };
 
   idea-community = buildIdea rec {
@@ -300,7 +300,7 @@ in
       sha256 = products.idea-community.sha256;
     };
     wmClass = "jetbrains-idea-ce";
-    update-channel = "IntelliJ IDEA RELEASE";
+    update-channel = products.idea-community.update-channel;
   };
 
   idea-ultimate = buildIdea rec {
@@ -314,12 +314,12 @@ in
       sha256 = products.idea-ultimate.sha256;
     };
     wmClass = "jetbrains-idea";
-    update-channel = "IntelliJ IDEA RELEASE";
+    update-channel = products.idea-ultimate.update-channel;
   };
 
   mps = buildMps rec {
     pname = "mps";
-    product = "MPS ${products.mps.version-major-minor}";
+    product = "MPS ${products.mps.version}";
     version = products.mps.version;
     description = "Create your own domain-specific language";
     license = lib.licenses.asl20;
@@ -328,7 +328,7 @@ in
       sha256 = products.mps.sha256;
     };
     wmClass = "jetbrains-mps";
-    update-channel = "MPS RELEASE";
+    update-channel = products.mps.update-channel;
   };
 
   phpstorm = buildPhpStorm rec {
@@ -341,7 +341,7 @@ in
       sha256 = products.phpstorm.sha256;
     };
     wmClass = "jetbrains-phpstorm";
-    update-channel = "PhpStorm RELEASE";
+    update-channel = products.phpstorm.update-channel;
   };
 
   pycharm-community = buildPycharm rec {
@@ -355,7 +355,7 @@ in
       sha256 = products.pycharm-community.sha256;
     };
     wmClass = "jetbrains-pycharm-ce";
-    update-channel = "PyCharm RELEASE";
+    update-channel = products.pycharm-community.update-channel;
   };
 
   pycharm-professional = buildPycharm rec {
@@ -369,7 +369,7 @@ in
       sha256 = products.pycharm-professional.sha256;
     };
     wmClass = "jetbrains-pycharm";
-    update-channel = "PyCharm RELEASE";
+    update-channel = products.pycharm-professional.update-channel;
   };
 
   rider = buildRider rec {
@@ -382,7 +382,7 @@ in
       sha256 = products.rider.sha256;
     };
     wmClass = "jetbrains-rider";
-    update-channel = "Rider RELEASE";
+    update-channel = products.rider.update-channel;
   };
 
   ruby-mine = buildRubyMine rec {
@@ -395,7 +395,7 @@ in
       sha256 = products.ruby-mine.sha256;
     };
     wmClass = "jetbrains-rubymine";
-    update-channel = "RubyMine RELEASE";
+    update-channel = products.ruby-mine.update-channel;
   };
 
   webstorm = buildWebStorm rec {
@@ -408,7 +408,7 @@ in
       sha256 = products.webstorm.sha256;
     };
     wmClass = "jetbrains-webstorm";
-    update-channel = "WebStorm RELEASE";
+    update-channel = products.webstorm.update-channel;
   };
 
 }

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -124,7 +124,7 @@ let
           with JUnit, TestNG, popular SCMs, Ant & Maven. Also known
           as IntelliJ.
         '';
-        maintainers = with maintainers; [ edwtjo gytis-ivaskevicius steinybot ];
+        maintainers = with maintainers; [ edwtjo gytis-ivaskevicius steinybot AnatolyPopov ];
         platforms = ideaPlatforms;
       };
     });

--- a/pkgs/applications/editors/jetbrains/update.py
+++ b/pkgs/applications/editors/jetbrains/update.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i python3 -p python3 python3.pkgs.packaging python3.pkgs.requests python3.pkgs.xmltodict
-import hashlib
 import json
 import pathlib
 import logging
@@ -33,7 +32,8 @@ def download_channels():
 
 
 def build_version(build):
-    return version.parse(build["@version"])
+    build_number = build["@fullNumber"] if "@fullNumber" in build else build["@number"]
+    return version.parse(build_number)
 
 
 def latest_build(channel):
@@ -43,11 +43,10 @@ def latest_build(channel):
 
 
 def download_sha256(url):
+    url = f"{url}.sha256"
     download_response = requests.get(url)
     download_response.raise_for_status()
-    h = hashlib.sha256()
-    h.update(download_response.content)
-    return h.hexdigest()
+    return download_response.content.decode('UTF-8').split(' ')[0]
 
 
 channels = download_channels()
@@ -63,18 +62,20 @@ def update_product(name, product):
     else:
         try:
             build = latest_build(channel)
-            version = build["@version"]
-            parsed_version = build_version(build)
-            version_major_minor = f"{parsed_version.major}.{parsed_version.minor}"
-            download_url = product["url-template"].format(version = version, versionMajorMinor = version_major_minor)
+            if "EAP" not in channel["@name"]:
+                version_or_build_number = build["@version"]
+            else:
+                version_or_build_number = build["@fullNumber"]
+            version_number = build["@version"].split(' ')[0]
+            download_url = product["url-template"].format(version=version_or_build_number, versionMajorMinor=version_number)
+            product["version-major-minor"] = version_number
             product["url"] = download_url
-            product["version-major-minor"] = version_major_minor
-            if "sha256" not in product or product.get("version") != version:
-                logging.info("Found a newer version %s.", version)
-                product["version"] = version
+            if "sha256" not in product or product.get("version") != version_or_build_number:
+                logging.info("Found a newer version %s.", version_or_build_number)
+                product["version"] = version_or_build_number
                 product["sha256"] = download_sha256(download_url)
             else:
-                logging.info("Already at the latest version %s.", version)
+                logging.info("Already at the latest version %s.", version_or_build_number)
         except Exception as e:
             logging.exception("Update failed:", exc_info=e)
             logging.warning("Skipping %s due to the above error.", name)

--- a/pkgs/applications/editors/jetbrains/versions.json
+++ b/pkgs/applications/editors/jetbrains/versions.json
@@ -1,296 +1,501 @@
 {
-  "linux": {
-    "clion": {
-      "update-channel": "CLion RELEASE",
-      "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
-      "version": "2021.3.3",
-      "sha256": "35986be8adfe0a291a0d2d550c1bf4861ae6c33ecbc71198a472e0ac01a0f10d",
-      "url": "https://download.jetbrains.com/cpp/CLion-2021.3.3.tar.gz",
-      "version-major-minor": "2021.3"
+  "eap": {
+    "aarch64-darwin": {
+      "clion": {
+        "sha256": "a941d24d8961e9986bda52133a33b2ed338b67fe8bba326e79b65598d9256e27",
+        "update-channel": "CLion EAP",
+        "url": "https://download.jetbrains.com/cpp/CLion-221.5080.93-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.dmg",
+        "version": "2022.1 Beta"
+      },
+      "datagrip": {
+        "sha256": "130a65ff6b1e93c7f894f624fab092cde5d4f74e4e898b4b6594ca38f1d39b8c",
+        "update-channel": "DataGrip EAP",
+        "url": "https://download.jetbrains.com/datagrip/datagrip-221.5080.106-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.dmg",
+        "version": "2022.1 EAP"
+      },
+      "goland": {
+        "sha256": "2e9bc636715c593ad3564a830a14e85d4d1c33355dfc4cdbed25330770daec21",
+        "update-channel": "GoLand EAP",
+        "url": "https://download.jetbrains.com/go/goland-221.5080.97-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.dmg",
+        "version": "2022.1 Beta 2"
+      },
+      "idea-community": {
+        "sha256": "f9e9087af672741d2472b60db16945962137a14be234113553f6931ce7715cd4",
+        "update-channel": "IntelliJ IDEA EAP",
+        "url": "https://download.jetbrains.com/idea/ideaIC-221.5080.93-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.dmg",
+        "version": "2022.1 Beta"
+      },
+      "idea-ultimate": {
+        "sha256": "4e7d5f2969bb916310cdc8607d7585dac2d42802427973ee9e9b67f6a6d237dd",
+        "update-channel": "IntelliJ IDEA EAP",
+        "url": "https://download.jetbrains.com/idea/ideaIU-221.5080.93-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.dmg",
+        "version": "2022.1 Beta"
+      },
+      "phpstorm": {
+        "sha256": "c8e1baa5f2e133336146c13b53bc139039505eb12aa9158d6a783c6f945fd808",
+        "update-channel": "PhpStorm EAP",
+        "url": "https://download.jetbrains.com/webide/PhpStorm-221.5080.66-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.dmg",
+        "version": "2022.1 EAP"
+      },
+      "pycharm-community": {
+        "sha256": "a45b07db75f05d2eb2fcd066c4349458a207ab334f5a94cc3793f7993fa622e0",
+        "update-channel": "PyCharm EAP",
+        "url": "https://download.jetbrains.com/python/pycharm-community-221.4994.44-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.dmg",
+        "version": "2022.1 EAP"
+      },
+      "pycharm-professional": {
+        "sha256": "1c3b15b2f685b4c522346e133f06488a764cc87317db4b9975cda15b078bfae6",
+        "update-channel": "PyCharm EAP",
+        "url": "https://download.jetbrains.com/python/pycharm-professional-221.4994.44-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.dmg",
+        "version": "2022.1 EAP"
+      },
+      "rider": {
+        "sha256": "a7d83537c8107fd5dd02a81312806ca1d1deb311567d8e4a4cfac45e078e63a0",
+        "update-channel": "Rider EAP",
+        "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2022.1-EAP10-221.5080.209-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{versionMajorMinor}-{version}-aarch64.dmg",
+        "version": "2022.1-EAP10 RC"
+      },
+      "ruby-mine": {
+        "sha256": "822b6f6f53ccfa35108a0775cb818ec72f32f07c2d60cf159ab63da6f94f601b",
+        "update-channel": "RubyMine EAP",
+        "url": "https://download.jetbrains.com/ruby/RubyMine-221.5080.154-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.dmg",
+        "version": "2022.1 RC"
+      },
+      "webstorm": {
+        "sha256": "8cfaa73226f582a0d4c60501097cec442943066383f37a28fd65d4ee51a776db",
+        "update-channel": "WebStorm EAP",
+        "url": "https://download.jetbrains.com/webstorm/WebStorm-221.5080.96-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.dmg",
+        "version": "2022.1 Beta"
+      }
     },
-    "datagrip": {
-      "update-channel": "DataGrip RELEASE",
-      "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.tar.gz",
-      "version": "2021.3.4",
-      "sha256": "a34670f1a6c77e00237302a70f22fb5bf089dfe128341fd89b2f25bb8becb325",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2021.3.4.tar.gz",
-      "version-major-minor": "2021.3"
+    "linux": {
+      "clion": {
+        "sha256": "73ec43ea7793e1109ee3471e3a7cf4c576fd4d2249555a7c1064193b8757bbd5",
+        "update-channel": "CLion EAP",
+        "url": "https://download.jetbrains.com/cpp/CLion-221.5080.93.tar.gz",
+        "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
+        "version": "2022.1 Beta"
+      },
+      "datagrip": {
+        "sha256": "6e05d18ce2e51784e300b002570a5daef8570278c628db3ea085b6fdc9e24266",
+        "update-channel": "DataGrip EAP",
+        "url": "https://download.jetbrains.com/datagrip/datagrip-221.5080.106.tar.gz",
+        "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.tar.gz",
+        "version": "2022.1 EAP"
+      },
+      "goland": {
+        "sha256": "f0e45fb35885d3eed586cba63622d1914aa1c55f2e1586fb46d5e9077e1f16cd",
+        "update-channel": "GoLand EAP",
+        "url": "https://download.jetbrains.com/go/goland-221.5080.97.tar.gz",
+        "url-template": "https://download.jetbrains.com/go/goland-{version}.tar.gz",
+        "version": "2022.1 Beta 2"
+      },
+      "idea-community": {
+        "sha256": "de31ebc6a6e15420649e09206a2e58c12880527257e62bc6d65bed553e960a6b",
+        "update-channel": "IntelliJ IDEA EAP",
+        "url": "https://download.jetbrains.com/idea/ideaIC-221.5080.93.tar.gz",
+        "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.tar.gz",
+        "version": "2022.1 Beta"
+      },
+      "idea-ultimate": {
+        "sha256": "d45fe86ac2d07de775f2bfc1b7d53912f6ea1348bec82ba26e898b00694d521e",
+        "update-channel": "IntelliJ IDEA EAP",
+        "url": "https://download.jetbrains.com/idea/ideaIU-221.5080.93-no-jbr.tar.gz",
+        "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-no-jbr.tar.gz",
+        "version": "2022.1 Beta"
+      },
+      "phpstorm": {
+        "sha256": "141c39ea8455ffc2d7dff0ca87820561e6daf94c12f09b5fc3fab2452379cae6",
+        "update-channel": "PhpStorm EAP",
+        "url": "https://download.jetbrains.com/webide/PhpStorm-221.5080.66.tar.gz",
+        "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.tar.gz",
+        "version": "2022.1 EAP"
+      },
+      "pycharm-community": {
+        "sha256": "318d9fb938872ef41801c953b7e7418901ed2dea69bb9aa6e7c2702de89c5877",
+        "update-channel": "PyCharm EAP",
+        "url": "https://download.jetbrains.com/python/pycharm-community-221.4994.44.tar.gz",
+        "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.tar.gz",
+        "version": "2022.1 EAP"
+      },
+      "pycharm-professional": {
+        "sha256": "e0a1bb459bba5ef2f64eb3ec42cbdf99b40ddad398115e76084647c1a5975c68",
+        "update-channel": "PyCharm EAP",
+        "url": "https://download.jetbrains.com/python/pycharm-professional-221.4994.44.tar.gz",
+        "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.tar.gz",
+        "version": "2022.1 EAP"
+      },
+      "rider": {
+        "sha256": "476e37bbfd410b26178d7213c4d5ebc2549cbce27811b3ace60cf919d4587f52",
+        "update-channel": "Rider EAP",
+        "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2022.1-EAP10-221.5080.209.tar.gz",
+        "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{versionMajorMinor}-{version}.tar.gz",
+        "version": "2022.1-EAP10 RC"
+      },
+      "ruby-mine": {
+        "sha256": "a343d95c11a2a9ae0b11cbce1dfdea7e89a19513831e5f5daa2da69625814605",
+        "update-channel": "RubyMine EAP",
+        "url": "https://download.jetbrains.com/ruby/RubyMine-221.5080.154.tar.gz",
+        "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.tar.gz",
+        "version": "2022.1 RC"
+      },
+      "webstorm": {
+        "sha256": "0f4029e5aacc29e3490b7060ec95eddb4de5b8b4fa53de43b49965dbc32d3846",
+        "update-channel": "WebStorm EAP",
+        "url": "https://download.jetbrains.com/webstorm/WebStorm-221.5080.96.tar.gz",
+        "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
+        "version": "2022.1 Beta"
+      }
     },
-    "goland": {
-      "update-channel": "GoLand RELEASE",
-      "url-template": "https://download.jetbrains.com/go/goland-{version}.tar.gz",
-      "version": "2021.3.3",
-      "sha256": "9d2b709703516eddeb7f4d6568a7de2e268de4258c7bc7787baee806fbaee4a3",
-      "url": "https://download.jetbrains.com/go/goland-2021.3.3.tar.gz",
-      "version-major-minor": "2021.3"
-    },
-    "idea-community": {
-      "update-channel": "IntelliJ IDEA RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.tar.gz",
-      "version": "2022.1",
-      "sha256": "0400e6152fa0173e4e9a514c6398eef8f19150893298658c0b3eb1427e5bcbe5",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2022.1.tar.gz",
-      "version-major-minor": "2022.1"
-    },
-    "idea-ultimate": {
-      "update-channel": "IntelliJ IDEA RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-no-jbr.tar.gz",
-      "version": "2022.1",
-      "sha256": "f786bbd4a7c82273f6871996584fb7b37aa2b32fb07c7f554076f203284c77b6",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2022.1-no-jbr.tar.gz",
-      "version-major-minor": "2022.1"
-    },
-    "mps": {
-      "update-channel": "MPS RELEASE",
-      "url-template": "https://download.jetbrains.com/mps/{versionMajorMinor}/MPS-{version}.tar.gz",
-      "version": "2021.3",
-      "sha256": "e9aeb62f0d667dd285f808e3ba308f572797dbf11d51e9aa06cf49481bee857f",
-      "url": "https://download.jetbrains.com/mps/2021.3/MPS-2021.3.tar.gz",
-      "version-major-minor": "2021.3"
-    },
-    "phpstorm": {
-      "update-channel": "PhpStorm RELEASE",
-      "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.tar.gz",
-      "version": "2021.3.2",
-      "sha256": "761b347142035e8b74cc5a9939100af9d45f1f6ee29de1e78cd6b1ff06fe20e2",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2021.3.2.tar.gz",
-      "version-major-minor": "2021.3"
-    },
-    "pycharm-community": {
-      "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.tar.gz",
-      "version": "2021.3.2",
-      "sha256": "f1ae01f471d01c6f09aab0a761c6dea9834ef584f2aaf6d6ebecdce6b55a66e8",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2021.3.2.tar.gz",
-      "version-major-minor": "2021.3"
-    },
-    "pycharm-professional": {
-      "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.tar.gz",
-      "version": "2021.3.2",
-      "sha256": "6bd9573a84c1f2ae6b9b6612f0859aee21133f479ace43602dc0af879f9d9e67",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2021.3.2.tar.gz",
-      "version-major-minor": "2021.3"
-    },
-    "rider": {
-      "update-channel": "Rider RELEASE",
-      "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.tar.gz",
-      "version": "2021.3.3",
-      "sha256": "1dc57d5d7932d4a8dea51fc5cbdaa52f9626490092978f02fa15bb41cb84068f",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2021.3.3.tar.gz",
-      "version-major-minor": "2021.3"
-    },
-    "ruby-mine": {
-      "update-channel": "RubyMine RELEASE",
-      "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.tar.gz",
-      "version": "2021.3.2",
-      "sha256": "697510ee2401bb7cbe75193f015d8c2dd1677117defbc2a6f5f3c1443f20dea2",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2021.3.2.tar.gz",
-      "version-major-minor": "2021.3"
-    },
-    "webstorm": {
-      "update-channel": "WebStorm RELEASE",
-      "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
-      "version": "2021.3.2",
-      "sha256": "18a53c1b1b92e9b7e516b425a390f23f46b880a704d1cb223d1ba64410b15060",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2021.3.2.tar.gz",
-      "version-major-minor": "2021.3"
+    "x86_64-darwin": {
+      "clion": {
+        "sha256": "ec8f93a9bd3af19364e392222b09f1afd898105641fc9cfcf244057fb08ccbab",
+        "update-channel": "CLion EAP",
+        "url": "https://download.jetbrains.com/cpp/CLion-221.5080.93.dmg",
+        "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.dmg",
+        "version": "2022.1 Beta"
+      },
+      "datagrip": {
+        "sha256": "658f7c7560b8529ad9b983a10bf93817f2e43b4126ca1e0d3141391f0844459f",
+        "update-channel": "DataGrip EAP",
+        "url": "https://download.jetbrains.com/datagrip/datagrip-221.5080.106.dmg",
+        "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.dmg",
+        "version": "2022.1 EAP"
+      },
+      "goland": {
+        "sha256": "7b10eaf811f508d732e9ed9e993405acac85cddb2dd1aaef335257c221d96896",
+        "update-channel": "GoLand EAP",
+        "url": "https://download.jetbrains.com/go/goland-221.5080.97.dmg",
+        "url-template": "https://download.jetbrains.com/go/goland-{version}.dmg",
+        "version": "2022.1 Beta 2"
+      },
+      "idea-community": {
+        "sha256": "22a382ccf914e56b8f73db7ec496ea58335067503989633f8b2e7d6bbbeeb36a",
+        "update-channel": "IntelliJ IDEA EAP",
+        "url": "https://download.jetbrains.com/idea/ideaIC-221.5080.93.dmg",
+        "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.dmg",
+        "version": "2022.1 Beta"
+      },
+      "idea-ultimate": {
+        "sha256": "e5d2e50554684ed6f3a924be38152486c3e817479502e0612b4b64cd46e392e0",
+        "update-channel": "IntelliJ IDEA EAP",
+        "url": "https://download.jetbrains.com/idea/ideaIU-221.5080.93.dmg",
+        "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.dmg",
+        "version": "2022.1 Beta"
+      },
+      "phpstorm": {
+        "sha256": "91b092c9e1011a382c596416f05127c8983a1f465af0365d5245d5f1e1eeb252",
+        "update-channel": "PhpStorm EAP",
+        "url": "https://download.jetbrains.com/webide/PhpStorm-221.5080.66.dmg",
+        "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.dmg",
+        "version": "2022.1 EAP"
+      },
+      "pycharm-community": {
+        "sha256": "295b80c4d4496cd6d3678e90d1aed89802274fcc6b86e9988004a920c36bcf4e",
+        "update-channel": "PyCharm EAP",
+        "url": "https://download.jetbrains.com/python/pycharm-community-221.4994.44.dmg",
+        "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.dmg",
+        "version": "2022.1 EAP"
+      },
+      "pycharm-professional": {
+        "sha256": "5119a74cd5eebba58838cd017fb372fd526ddc2d0d497ee6aefd2df528f77f5f",
+        "update-channel": "PyCharm EAP",
+        "url": "https://download.jetbrains.com/python/pycharm-professional-221.4994.44.dmg",
+        "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.dmg",
+        "version": "2022.1 EAP"
+      },
+      "rider": {
+        "sha256": "35eb648d5a491f3d878cd02d935ea938f14a07df40306971afab04fbc924bb73",
+        "update-channel": "Rider EAP",
+        "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2022.1-EAP10-221.5080.209.dmg",
+        "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{versionMajorMinor}-{version}.dmg",
+        "version": "2022.1-EAP10 RC"
+      },
+      "ruby-mine": {
+        "sha256": "5a7aa054cc8fa2121472c0d33aee484c0438cd9720919a6f077f2d07cf43f50e",
+        "update-channel": "RubyMine EAP",
+        "url": "https://download.jetbrains.com/ruby/RubyMine-221.5080.154.dmg",
+        "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.dmg",
+        "version": "2022.1 RC"
+      },
+      "webstorm": {
+        "sha256": "811c6b3933232b2213753833c38a10dea1bcbb2756e2fd3467e3bbae0d193c37",
+        "update-channel": "WebStorm EAP",
+        "url": "https://download.jetbrains.com/webstorm/WebStorm-221.5080.96.dmg",
+        "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.dmg",
+        "version": "2022.1 Beta"
+      }
     }
   },
-  "x86_64-darwin": {
-    "clion": {
-      "update-channel": "CLion RELEASE",
-      "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.dmg",
-      "version": "2021.3.3",
-      "sha256": "342a4d8549ae4623a5edfa7f9737887cf0a25c1a61bb414b54b742b1c5a1a84d",
-      "url": "https://download.jetbrains.com/cpp/CLion-2021.3.3.dmg",
-      "version-major-minor": "2021.3"
+  "release": {
+    "aarch64-darwin": {
+      "clion": {
+        "sha256": "333d4ac5757f537ad67863dd6fb03644722ab8fce1596976fa99e5ae9de7991c",
+        "update-channel": "CLion RELEASE",
+        "url": "https://download.jetbrains.com/cpp/CLion-2022.1-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.dmg",
+        "version": "2022.1"
+      },
+      "datagrip": {
+        "sha256": "2ba92ed34366b111a39ba0632d91dbaf232633f5f5557a208dd8ab7696179b6f",
+        "update-channel": "DataGrip RELEASE",
+        "url": "https://download.jetbrains.com/datagrip/datagrip-2022.1.1-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.dmg",
+        "version": "2022.1.1"
+      },
+      "goland": {
+        "sha256": "0506a817e35a80d3d776484a88bf4136628b589a8f5754833387a8dec99798d3",
+        "update-channel": "GoLand RELEASE",
+        "url": "https://download.jetbrains.com/go/goland-2022.1-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.dmg",
+        "version": "2022.1"
+      },
+      "idea-community": {
+        "sha256": "f61bdf70e373a948a71331e68a7303bf90cf47ea4e2f97338aaf96d19e8862c4",
+        "update-channel": "IntelliJ IDEA RELEASE",
+        "url": "https://download.jetbrains.com/idea/ideaIC-2022.1-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.dmg",
+        "version": "2022.1"
+      },
+      "idea-ultimate": {
+        "sha256": "af9c0e8d47fcded5f567293b7991fd0ac8df838b83884149109fd91ec2dec769",
+        "update-channel": "IntelliJ IDEA RELEASE",
+        "url": "https://download.jetbrains.com/idea/ideaIU-2022.1-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.dmg",
+        "version": "2022.1"
+      },
+      "mps": {
+        "sha256": "3ace6d45db718dffd80bf126a76735fb65099de292112a01cc078aa61c475a70",
+        "update-channel": "MPS RELEASE",
+        "url": "https://download.jetbrains.com/mps/2021.3/MPS-2021.3-macos-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/mps/{versionMajorMinor}/MPS-{version}-macos-aarch64.dmg",
+        "version": "2021.3"
+      },
+      "phpstorm": {
+        "sha256": "d13744e7a70a9716f1b99cb9b77c77e17cb4710466a29db490ef6e707a54ae21",
+        "update-channel": "PhpStorm RELEASE",
+        "url": "https://download.jetbrains.com/webide/PhpStorm-2022.1-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.dmg",
+        "version": "2022.1"
+      },
+      "pycharm-community": {
+        "sha256": "1873565756716cb0eee23c60068dd5d394413b2b2e54b4b75cbe8b882540a0b7",
+        "update-channel": "PyCharm RELEASE",
+        "url": "https://download.jetbrains.com/python/pycharm-community-2022.1-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.dmg",
+        "version": "2022.1"
+      },
+      "pycharm-professional": {
+        "sha256": "ba0ea4ff52703a53a9c7e14d42c9ae12688b94364ced77a28d4ed0c417c9642f",
+        "update-channel": "PyCharm RELEASE",
+        "url": "https://download.jetbrains.com/python/pycharm-professional-2022.1-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.dmg",
+        "version": "2022.1"
+      },
+      "rider": {
+        "sha256": "273f40eda119a034ada821db2257e3b5c2bfb835c287365398237f5d9a9daad3",
+        "update-channel": "Rider RELEASE",
+        "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2022.1-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.dmg",
+        "version": "2022.1"
+      },
+      "ruby-mine": {
+        "sha256": "06d932a587adcd25b4e70d0b27c2c229381144deaef90cbcdc345edd822e04ed",
+        "update-channel": "RubyMine RELEASE",
+        "url": "https://download.jetbrains.com/ruby/RubyMine-2022.1-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.dmg",
+        "version": "2022.1"
+      },
+      "webstorm": {
+        "sha256": "96ec148af1b20ea9d2cb6f8b1f268f96607269e8dd3caf521b48464fe21a7177",
+        "update-channel": "WebStorm RELEASE",
+        "url": "https://download.jetbrains.com/webstorm/WebStorm-2022.1-aarch64.dmg",
+        "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.dmg",
+        "version": "2022.1"
+      }
     },
-    "datagrip": {
-      "update-channel": "DataGrip RELEASE",
-      "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.dmg",
-      "version": "2021.3.4",
-      "sha256": "27e709d2ced66d37a615d8c56885828e49a08962708e28df1a20f324c626bf52",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2021.3.4.dmg",
-      "version-major-minor": "2021.3"
+    "linux": {
+      "clion": {
+        "sha256": "a8ad8db6362d60a5ce60a7552110887dbd12e8420c839c368b55808b68dea38b",
+        "update-channel": "CLion RELEASE",
+        "url": "https://download.jetbrains.com/cpp/CLion-2022.1.tar.gz",
+        "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
+        "version": "2022.1"
+      },
+      "datagrip": {
+        "sha256": "d4ffcb4371ee6e9f03704fa6282630349fd4ff4759846c02d43bb37e3caeae67",
+        "update-channel": "DataGrip RELEASE",
+        "url": "https://download.jetbrains.com/datagrip/datagrip-2022.1.1.tar.gz",
+        "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.tar.gz",
+        "version": "2022.1.1"
+      },
+      "goland": {
+        "sha256": "7803f432b62b7b9a9f340fd48375f50d60b0e5412b052b70e175de8edf82a947",
+        "update-channel": "GoLand RELEASE",
+        "url": "https://download.jetbrains.com/go/goland-2022.1.tar.gz",
+        "url-template": "https://download.jetbrains.com/go/goland-{version}.tar.gz",
+        "version": "2022.1"
+      },
+      "idea-community": {
+        "sha256": "0400e6152fa0173e4e9a514c6398eef8f19150893298658c0b3eb1427e5bcbe5",
+        "update-channel": "IntelliJ IDEA RELEASE",
+        "url": "https://download.jetbrains.com/idea/ideaIC-2022.1.tar.gz",
+        "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.tar.gz",
+        "version": "2022.1"
+      },
+      "idea-ultimate": {
+        "sha256": "f786bbd4a7c82273f6871996584fb7b37aa2b32fb07c7f554076f203284c77b6",
+        "update-channel": "IntelliJ IDEA RELEASE",
+        "url": "https://download.jetbrains.com/idea/ideaIU-2022.1-no-jbr.tar.gz",
+        "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-no-jbr.tar.gz",
+        "version": "2022.1"
+      },
+      "mps": {
+        "sha256": "e9aeb62f0d667dd285f808e3ba308f572797dbf11d51e9aa06cf49481bee857f",
+        "update-channel": "MPS RELEASE",
+        "url": "https://download.jetbrains.com/mps/2021.3/MPS-2021.3.tar.gz",
+        "url-template": "https://download.jetbrains.com/mps/{versionMajorMinor}/MPS-{version}.tar.gz",
+        "version": "2021.3"
+      },
+      "phpstorm": {
+        "sha256": "e30d6991c98addcc02ab05c623d0c42797d605db73c01b7c153bf2246c877395",
+        "update-channel": "PhpStorm RELEASE",
+        "url": "https://download.jetbrains.com/webide/PhpStorm-2022.1.tar.gz",
+        "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.tar.gz",
+        "version": "2022.1"
+      },
+      "pycharm-community": {
+        "sha256": "35d857df0ac4bd76caba60ac329c9183594be142094d0592f2afa40534be85eb",
+        "update-channel": "PyCharm RELEASE",
+        "url": "https://download.jetbrains.com/python/pycharm-community-2022.1.tar.gz",
+        "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.tar.gz",
+        "version": "2022.1"
+      },
+      "pycharm-professional": {
+        "sha256": "9b160ed74f384be31ff376af73f91924a212e6440ce142a581b22f261e6cf605",
+        "update-channel": "PyCharm RELEASE",
+        "url": "https://download.jetbrains.com/python/pycharm-professional-2022.1.tar.gz",
+        "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.tar.gz",
+        "version": "2022.1"
+      },
+      "rider": {
+        "sha256": "23e25542f7bae972c64bca09ffcd60b629db9b848067b2268054c97f6a467196",
+        "update-channel": "Rider RELEASE",
+        "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2022.1.Checked.tar.gz",
+        "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.Checked.tar.gz",
+        "version": "2022.1"
+      },
+      "ruby-mine": {
+        "sha256": "495c0d86eb7f3bed0ed692a7ae37e8b3b333c58ae891ca3891a311db6b951401",
+        "update-channel": "RubyMine RELEASE",
+        "url": "https://download.jetbrains.com/ruby/RubyMine-2022.1.tar.gz",
+        "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.tar.gz",
+        "version": "2022.1"
+      },
+      "webstorm": {
+        "sha256": "d9dd5815cc456d74f7dc47533ade3990d0f2f9ce0c4dab3d5ae9b04e01d1746c",
+        "update-channel": "WebStorm RELEASE",
+        "url": "https://download.jetbrains.com/webstorm/WebStorm-2022.1.tar.gz",
+        "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
+        "version": "2022.1"
+      }
     },
-    "goland": {
-      "update-channel": "GoLand RELEASE",
-      "url-template": "https://download.jetbrains.com/go/goland-{version}.dmg",
-      "version": "2021.3.3",
-      "sha256": "4b245b6fe0cf588adbf36e68f12397d5fd311b0b6d49f17ba374ebaa10d207c9",
-      "url": "https://download.jetbrains.com/go/goland-2021.3.3.dmg",
-      "version-major-minor": "2021.3"
-    },
-    "idea-community": {
-      "update-channel": "IntelliJ IDEA RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.dmg",
-      "version": "2022.1",
-      "sha256": "6f9dddab5c280bb2ad6bb8d46bcc85c1b167974ce4b412a68faf31f7f7d1c194",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2022.1.dmg",
-      "version-major-minor": "2022.1"
-    },
-    "idea-ultimate": {
-      "update-channel": "IntelliJ IDEA RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.dmg",
-      "version": "2022.1",
-      "sha256": "2f1e51db514b39b54cb4029815b7f92764b378f2cf2eb16e69e2ee3c0b35f416",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2022.1.dmg",
-      "version-major-minor": "2022.1"
-    },
-    "mps": {
-      "update-channel": "MPS RELEASE",
-      "url-template": "https://download.jetbrains.com/mps/{versionMajorMinor}/MPS-{version}-macos.dmg",
-      "version": "2021.3",
-      "sha256": "2c5517518fec31ac960e4309fa848ad831f9048ef15df1b362e12aa8f41d9dbd",
-      "url": "https://download.jetbrains.com/mps/2021.3/MPS-2021.3-macos.dmg",
-      "version-major-minor": "2021.3"
-    },
-    "phpstorm": {
-      "update-channel": "PhpStorm RELEASE",
-      "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.dmg",
-      "version": "2021.3.2",
-      "sha256": "596a9d5fdc30d5fba65ddd482da90f9d555fed748b930587562022bfe7df4e14",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2021.3.2.dmg",
-      "version-major-minor": "2021.3"
-    },
-    "pycharm-community": {
-      "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.dmg",
-      "version": "2021.3.2",
-      "sha256": "b8f41f5dddeda0ed5f5c81ba57d2560ccc6e227987882fb6bf305b5d1d8c6909",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2021.3.2.dmg",
-      "version-major-minor": "2021.3"
-    },
-    "pycharm-professional": {
-      "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.dmg",
-      "version": "2021.3.2",
-      "sha256": "188b998660e7cfb7ac1364c818c008a5608ab2aeb17c6cc19d1d9dda547d3775",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2021.3.2.dmg",
-      "version-major-minor": "2021.3"
-    },
-    "rider": {
-      "update-channel": "Rider RELEASE",
-      "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.dmg",
-      "version": "2021.3.3",
-      "sha256": "41a0939cb6258a0fb303268c5a466a663cf3588af14bcbb351be4c3a1d158094",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2021.3.3.dmg",
-      "version-major-minor": "2021.3"
-    },
-    "ruby-mine": {
-      "update-channel": "RubyMine RELEASE",
-      "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.dmg",
-      "version": "2021.3.2",
-      "sha256": "ba27c14b21d66ca96a64ceb7dc5d9f0952254a5f405b3201f51d2ad3cc749a96",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2021.3.2.dmg",
-      "version-major-minor": "2021.3"
-    },
-    "webstorm": {
-      "update-channel": "WebStorm RELEASE",
-      "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.dmg",
-      "version": "2021.3.2",
-      "sha256": "932d4920f831d1ceae68a474444c37d986277d8d3288d3aab93dd43d99336a36",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2021.3.2.dmg",
-      "version-major-minor": "2021.3"
-    }
-  },
-  "aarch64-darwin": {
-    "clion": {
-      "update-channel": "CLion RELEASE",
-      "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.dmg",
-      "version": "2021.3.3",
-      "sha256": "fbf651fa4a5925fe729be30ca8a6fa3be84dc4d7827dbcf74f4d28c52b903cc2",
-      "url": "https://download.jetbrains.com/cpp/CLion-2021.3.3-aarch64.dmg",
-      "version-major-minor": "2021.3"
-    },
-    "datagrip": {
-      "update-channel": "DataGrip RELEASE",
-      "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.dmg",
-      "version": "2021.3.4",
-      "sha256": "7a77ba9fce56c781ae6a4fc65eaab4bcc10780b6bd679b04d74146719e42890a",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2021.3.4-aarch64.dmg",
-      "version-major-minor": "2021.3"
-    },
-    "goland": {
-      "update-channel": "GoLand RELEASE",
-      "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.dmg",
-      "version": "2021.3.3",
-      "sha256": "54397d48e20fb534206e13f84b35868b1eaea13175176487b1239b23db4e13db",
-      "url": "https://download.jetbrains.com/go/goland-2021.3.3-aarch64.dmg",
-      "version-major-minor": "2021.3"
-    },
-    "idea-community": {
-      "update-channel": "IntelliJ IDEA RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.dmg",
-      "version": "2022.1",
-      "sha256": "f61bdf70e373a948a71331e68a7303bf90cf47ea4e2f97338aaf96d19e8862c4",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2022.1-aarch64.dmg",
-      "version-major-minor": "2022.1"
-    },
-    "idea-ultimate": {
-      "update-channel": "IntelliJ IDEA RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.dmg",
-      "version": "2022.1",
-      "sha256": "af9c0e8d47fcded5f567293b7991fd0ac8df838b83884149109fd91ec2dec769",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2022.1-aarch64.dmg",
-      "version-major-minor": "2022.1"
-    },
-    "mps": {
-      "update-channel": "MPS RELEASE",
-      "url-template": "https://download.jetbrains.com/mps/{versionMajorMinor}/MPS-{version}-macos-aarch64.dmg",
-      "version": "2021.3",
-      "url": "https://download.jetbrains.com/mps/2021.3/MPS-2021.3-macos-aarch64.dmg",
-      "sha256": "3ace6d45db718dffd80bf126a76735fb65099de292112a01cc078aa61c475a70",
-      "version-major-minor": "2021.3"
-    },
-    "phpstorm": {
-      "update-channel": "PhpStorm RELEASE",
-      "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.dmg",
-      "version": "2021.3.2",
-      "sha256": "ba15c3f843c85141a9adaec1c4611224a853bd98649148751e34ac304591a314",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2021.3.2-aarch64.dmg",
-      "version-major-minor": "2021.3"
-    },
-    "pycharm-community": {
-      "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.dmg",
-      "version": "2021.3.2",
-      "sha256": "407bf395cfb6d61f1c0861c7679b197238780e82a019e10162b8cd7130edb15a",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2021.3.2-aarch64.dmg",
-      "version-major-minor": "2021.3"
-    },
-    "pycharm-professional": {
-      "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.dmg",
-      "version": "2021.3.2",
-      "sha256": "12fa34d1e60a555bac230acea9cd46c7adfe9ca42ff3e458c79d33e5b88eb8db",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2021.3.2-aarch64.dmg",
-      "version-major-minor": "2021.3"
-    },
-    "rider": {
-      "update-channel": "Rider RELEASE",
-      "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.dmg",
-      "version": "2021.3.3",
-      "sha256": "65603860d1fd3134c5659f5a06de7cac17f3183a01056b79cfe72242b99adb37",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2021.3.3-aarch64.dmg",
-      "version-major-minor": "2021.3"
-    },
-    "ruby-mine": {
-      "update-channel": "RubyMine RELEASE",
-      "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.dmg",
-      "version": "2021.3.2",
-      "sha256": "33773222b2fa14300de5ed12ca96c3442b933f66cef67cebc9610e5cef51c75e",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2021.3.2-aarch64.dmg",
-      "version-major-minor": "2021.3"
-    },
-    "webstorm": {
-      "update-channel": "WebStorm RELEASE",
-      "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.dmg",
-      "version": "2021.3.2",
-      "sha256": "f4788ec0c55123b1f4e14934792f65bf8040e2a2ee673e985b50b8feded60408",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2021.3.2-aarch64.dmg",
-      "version-major-minor": "2021.3"
+    "x86_64-darwin": {
+      "clion": {
+        "sha256": "4972403e5ed7587ad76dcfb08b975879a2a955e9be9f88344e369cd4006b2d52",
+        "update-channel": "CLion RELEASE",
+        "url": "https://download.jetbrains.com/cpp/CLion-2022.1.dmg",
+        "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.dmg",
+        "version": "2022.1"
+      },
+      "datagrip": {
+        "sha256": "6ea0c0c972bad06fd0378a2c1e9a1cb1b3ec50d52cc98d0f9c98327cc7af2a1e",
+        "update-channel": "DataGrip RELEASE",
+        "url": "https://download.jetbrains.com/datagrip/datagrip-2022.1.1.dmg",
+        "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.dmg",
+        "version": "2022.1.1"
+      },
+      "goland": {
+        "sha256": "ec44455e83b8c8d85614b63815245a0dff984796a432e05801787c7f8474900b",
+        "update-channel": "GoLand RELEASE",
+        "url": "https://download.jetbrains.com/go/goland-2022.1.dmg",
+        "url-template": "https://download.jetbrains.com/go/goland-{version}.dmg",
+        "version": "2022.1"
+      },
+      "idea-community": {
+        "sha256": "6f9dddab5c280bb2ad6bb8d46bcc85c1b167974ce4b412a68faf31f7f7d1c194",
+        "update-channel": "IntelliJ IDEA RELEASE",
+        "url": "https://download.jetbrains.com/idea/ideaIC-2022.1.dmg",
+        "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.dmg",
+        "version": "2022.1"
+      },
+      "idea-ultimate": {
+        "sha256": "2f1e51db514b39b54cb4029815b7f92764b378f2cf2eb16e69e2ee3c0b35f416",
+        "update-channel": "IntelliJ IDEA RELEASE",
+        "url": "https://download.jetbrains.com/idea/ideaIU-2022.1.dmg",
+        "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.dmg",
+        "version": "2022.1"
+      },
+      "mps": {
+        "sha256": "2c5517518fec31ac960e4309fa848ad831f9048ef15df1b362e12aa8f41d9dbd",
+        "update-channel": "MPS RELEASE",
+        "url": "https://download.jetbrains.com/mps/2021.3/MPS-2021.3-macos.dmg",
+        "url-template": "https://download.jetbrains.com/mps/{versionMajorMinor}/MPS-{version}-macos.dmg",
+        "version": "2021.3"
+      },
+      "phpstorm": {
+        "sha256": "daa3c749b3a41e106384ac8e003957a46f38dfc844cebfce8c802c4a223535b8",
+        "update-channel": "PhpStorm RELEASE",
+        "url": "https://download.jetbrains.com/webide/PhpStorm-2022.1.dmg",
+        "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.dmg",
+        "version": "2022.1"
+      },
+      "pycharm-community": {
+        "sha256": "99ba20a8b0752ca58e1fc814fb19766fd19c376b42e3cbfa4102c67bc21942ec",
+        "update-channel": "PyCharm RELEASE",
+        "url": "https://download.jetbrains.com/python/pycharm-community-2022.1.dmg",
+        "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.dmg",
+        "version": "2022.1"
+      },
+      "pycharm-professional": {
+        "sha256": "ab5496370a6145073dbd423e47d6112d9c726a4a286d2528e66711f865d92d56",
+        "update-channel": "PyCharm RELEASE",
+        "url": "https://download.jetbrains.com/python/pycharm-professional-2022.1.dmg",
+        "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.dmg",
+        "version": "2022.1"
+      },
+      "rider": {
+        "sha256": "12456837fcc7be92f1a19132c0e8b963d257e918199e1edec894af14d4337c47",
+        "update-channel": "Rider RELEASE",
+        "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2022.1.Checked.dmg",
+        "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.Checked.dmg",
+        "version": "2022.1"
+      },
+      "ruby-mine": {
+        "sha256": "b33f34b889fde6ebe6348499e2ad15bb85937aba1e2a8a9543c411b2476ec4ff",
+        "update-channel": "RubyMine RELEASE",
+        "url": "https://download.jetbrains.com/ruby/RubyMine-2022.1.dmg",
+        "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.dmg",
+        "version": "2022.1"
+      },
+      "webstorm": {
+        "sha256": "0bd2be5ea0ccabfb7a806ca4c46d33f1e9106c2256243c48091ff61d5ac29a08",
+        "update-channel": "WebStorm RELEASE",
+        "url": "https://download.jetbrains.com/webstorm/WebStorm-2022.1.dmg",
+        "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.dmg",
+        "version": "2022.1"
+      }
     }
   }
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26470,12 +26470,20 @@ with pkgs;
     inherit (qt5) wrapQtAppsHook;
   };
 
-  jetbrains = (recurseIntoAttrs (callPackages ../applications/editors/jetbrains {
-    vmopts = config.jetbrains.vmopts or null;
-    jdk = jetbrains.jdk;
-  }) // {
-    jdk = callPackage ../development/compilers/jetbrains-jdk {  };
-  });
+  jetbrains = (
+    recurseIntoAttrs (callPackages ../applications/editors/jetbrains {
+      vmopts = config.jetbrains.vmopts or null;
+      jdk = jetbrains.jdk;
+    }) //
+    lib.meta.lowPrioSet (recurseIntoAttrs (callPackages ../applications/editors/jetbrains {
+      vmopts = config.jetbrains.vmopts or null;
+      jdk = jetbrains.jdk;
+      channel = "eap";
+    })) //
+    {
+      jdk = callPackage ../development/compilers/jetbrains-jdk {  };
+    }
+  );
 
   jmusicbot = callPackage ../applications/audio/jmusicbot { };
 


### PR DESCRIPTION
Adds support for EAP packages.

```
> nix search . jetbrains --extra-experimental-features nix-command --extra-experimental-features flakes                                        ~/src/nixpkgs
* legacyPackages.aarch64-darwin.jetbrains.clion (2022.1)
  C/C++ IDE. New. Intelligent. Cross-platform

* legacyPackages.aarch64-darwin.jetbrains.clion-eap (2022.1-Beta)
  C/C++ IDE. New. Intelligent. Cross-platform

* legacyPackages.aarch64-darwin.jetbrains.datagrip (2022.1.1)
  Your Swiss Army Knife for Databases and SQL

* legacyPackages.aarch64-darwin.jetbrains.datagrip-eap (2022.1-EAP)
  Your Swiss Army Knife for Databases and SQL

* legacyPackages.aarch64-darwin.jetbrains.goland (2022.1)
  Up and Coming Go IDE

* legacyPackages.aarch64-darwin.jetbrains.goland-eap (2022.1-Beta-2)
  Up and Coming Go IDE

* legacyPackages.aarch64-darwin.jetbrains.idea-community (2022.1)
  Integrated Development Environment (IDE) by Jetbrains, community edition

* legacyPackages.aarch64-darwin.jetbrains.idea-community-eap (2022.1-Beta)
  Integrated Development Environment (IDE) by Jetbrains, community edition

* legacyPackages.aarch64-darwin.jetbrains.idea-ultimate (2022.1)
  Integrated Development Environment (IDE) by Jetbrains, requires paid license

* legacyPackages.aarch64-darwin.jetbrains.idea-ultimate-eap (2022.1-Beta)
  Integrated Development Environment (IDE) by Jetbrains, requires paid license

* legacyPackages.aarch64-darwin.jetbrains.jdk (11_0_13-b1751.25)
  An OpenJDK fork to better support Jetbrains's products.

* legacyPackages.aarch64-darwin.jetbrains.mps (2021.3)
  Create your own domain-specific language

* legacyPackages.aarch64-darwin.jetbrains.pycharm-community (2022.1)
  PyCharm Community Edition

* legacyPackages.aarch64-darwin.jetbrains.pycharm-community-eap (2022.1-EAP)
  PyCharm Community Edition

* legacyPackages.aarch64-darwin.jetbrains.pycharm-professional (2022.1)
  PyCharm Professional Edition

* legacyPackages.aarch64-darwin.jetbrains.pycharm-professional-eap (2022.1-EAP)
  PyCharm Professional Edition

* legacyPackages.aarch64-darwin.jetbrains.rider (2021.3.4)
  A cross-platform .NET IDE based on the IntelliJ platform and ReSharper

* legacyPackages.aarch64-darwin.jetbrains.rider-eap (2022.1-EAP10-RC)
  A cross-platform .NET IDE based on the IntelliJ platform and ReSharper

* legacyPackages.aarch64-darwin.jetbrains.ruby-mine (2022.1)
  The Most Intelligent Ruby and Rails IDE

* legacyPackages.aarch64-darwin.jetbrains.ruby-mine-eap (2022.1-RC)
  The Most Intelligent Ruby and Rails IDE

* legacyPackages.aarch64-darwin.jetbrains-mono (2.242)
  A typeface made for developers

* legacyPackages.aarch64-darwin.perl532Packages.DevelCamelcadedb (2021.2)
  Perl side of the Perl debugger for IntelliJ IDEA and other JetBrains IDEs

* legacyPackages.aarch64-darwin.perl534Packages.DevelCamelcadedb (2021.2)
  Perl side of the Perl debugger for IntelliJ IDEA and other JetBrains IDEs

* legacyPackages.aarch64-darwin.perlPackages.DevelCamelcadedb (2021.2)
  Perl side of the Perl debugger for IntelliJ IDEA and other JetBrains IDEs
```